### PR TITLE
Minor fixes for RC version detection, cli args handling and JVM arg temp file permissions

### DIFF
--- a/8.1/Makefile
+++ b/8.1/Makefile
@@ -4,7 +4,7 @@ export IGNITION_VERSION=$$(grep -Po '(?<=IGNITION_VERSION=\")((\d\.){2}\d)(?=\")
 # This version check leverages the above and aborts the build if not found
 export IGNITION_VERSION_CHECK=if [ -z "${IGNITION_VERSION}" ]; then exit 1; fi
 # Extract the IGNITION_RC_VERSION for release candidate, if applicable
-IGNITION_RC_VERSION:=$$(grep -Po '(?<=IGNITION_RC_VERSION=\")((\d\.){2}\d-rc\d)(?=\")' Dockerfile)
+IGNITION_RC_VERSION:=$$(grep -Po '(?<=IGNITION_RC_VERSION=\")((\d\.){2}\d+-rc\d)(?=\")' Dockerfile)
 # Pull in base options (if called from this directory)
 include ../.env
 

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -501,7 +501,7 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
 
     # Collect JVM Arguments
     if [[ ${#JVM_OPTIONS[@]} -gt 0 ]]; then
-        jvm_args_filepath=$(mktemp /tmp/ignition_jvm_args-XXXXXXX)
+        jvm_args_filepath=$(mktemp --tmpdir="${IGNITION_INSTALL_LOCATION}/temp" ignition_jvm_args-XXXXXXX)
         printf "#encoding=UTF-8\n" >> "${jvm_args_filepath}"
         for opt in "${JVM_OPTIONS[@]}"; do
             printf "%s\n" "${opt}" >> "${jvm_args_filepath}"
@@ -655,7 +655,7 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
     fi
     
     # Stage tini as init replacement
-    set -- tini -g --
+    set -- tini -g -- "${CMD[@]}"
 
     # Check for running as root and adjust permissions as needed, then stage dropdown to `ignition` user for gateway launch.
     if [ "$(id -u)" = "0" ]; then
@@ -708,4 +708,4 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
     echo 'init     | Starting Ignition Gateway...'
 fi
 
-exec "$@" "${CMD[@]}"
+exec "$@"


### PR DESCRIPTION
Missed a few things in #72 that showed up in some follow-up tests:
- JVM args are now collected in a file under Ignition `temp/` folder so that permissions adjustments (from root) are properly maintained.
- Processing of CLI args is corrected to allow supplemental wrapper/JVM args as well as running sh/bash directly (instead of starting gateway automatically).
- Release Candidate version detection corrected to allow multiple digits in patch level (i.e. 8.1.10-rc1).