### PR TITLE
Updated regex for subject name extraction for optional fields

### DIFF
--- a/8.1/register-modules.sh
+++ b/8.1/register-modules.sh
@@ -57,8 +57,8 @@ function register_modules() {
         local cert_info subject_name thumbprint next_certificates_id thumbprint_already_exists
         cert_info=$( unzip -qq -c "${module_sourcepath}" certificates.p7b | $keytool -printcert -v | head -n 9 ) 
         thumbprint=$( echo "${cert_info}" | grep -A 2 "Certificate fingerprints" | grep SHA1 | cut -d : -f 2- | sed -e 's/\://g' | awk '{$1=$1;print tolower($0)}' ) 
-        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN=\K(.+)(?=, OU)' | sed -e 's/"//g' )
         echo "init     |  Thumbprint: ${thumbprint}"
+        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
         echo "init     |  Subject Name: ${subject_name}"
         next_certificates_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(CERTIFICATES_ID)+1,1) FROM CERTIFICATES" ) 
         thumbprint_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM CERTIFICATES WHERE lower(hex(THUMBPRINT)) = '${thumbprint}'" )


### PR DESCRIPTION
This PR is to address an issue with module linking, specifically related to the extraction of the certificate Subject Name from the module file.  When the distinguished name did not have an OU field, the extraction match would fail, like reported in #79.  The regex now is more flexible for optional fields.

With this PR, I'll be doing an updates 8.1.10 and 8.1.11-rc1 image build/push.

Fixes #79