### PR TITLE
Added IGNITION_UID=0 option for root mode

### DIFF
--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -658,7 +658,7 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
     set -- tini -g -- "${CMD[@]}"
 
     # Check for running as root and adjust permissions as needed, then stage dropdown to `ignition` user for gateway launch.
-    if [ "$(id -u)" = "0" ]; then
+    if [ "$(id -u)" = "0" ] && [ "${IGNITION_UID}" != "0" ]; then
         # Obtain ignition UID/GID
         ignition_uid_current=$(id -u ignition)
         ignition_gid_current=$(id -g ignition)


### PR DESCRIPTION
Added option for having `IGNITION_UID=0` skip the permissions setting and stepdown-from-root functionality at the end of the entry point.  Should be useful for debugging.

Fixes #83 