### PR TITLE
Add symlink support for SSL and GAN keystores

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -104,9 +104,10 @@ RUN mkdir -p /var/lib/ignition && \
     ln -s /var/lib/ignition/data data && \
     ln -s /var/lib/ignition/user-lib user-lib && \
     ln -s /var/log/ignition logs && \
-    ln -s /var/lib/ignition/data/ssl.pfx webserver/ssl.pfx && \
-    ln -s /var/lib/ignition/data/csr.pfx webserver/csr.pfx && \
-    ln -s /var/lib/ignition/data/metro-keystore webserver/metro-keystore
+    mkdir -p /var/lib/ignition/data/local && \
+    ln -s /var/lib/ignition/data/local/ssl.pfx webserver/ssl.pfx && \
+    ln -s /var/lib/ignition/data/local/csr.pfx webserver/csr.pfx && \
+    ln -s /var/lib/ignition/data/local/metro-keystore webserver/metro-keystore
 
 # Extract embedded Java based on architecture
 RUN set -exo pipefail; \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -104,6 +104,8 @@ RUN mkdir -p /var/lib/ignition && \
     ln -s /var/lib/ignition/data data && \
     ln -s /var/lib/ignition/user-lib user-lib && \
     ln -s /var/log/ignition logs && \
+    ln -s /var/lib/ignition/data/ssl.pfx webserver/ssl.pfx && \
+    ln -s /var/lib/ignition/data/csr.pfx webserver/csr.pfx && \
     ln -s /var/lib/ignition/data/metro-keystore webserver/metro-keystore
 
 # Extract embedded Java based on architecture

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -162,7 +162,8 @@ COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /root/ignition ${
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/lib/ignition /var/lib/ignition
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/log/ignition /var/log/ignition
 COPY --from=downloader /root/gosu /usr/local/bin/
-RUN ln -s /dev/stdout /var/log/ignition/wrapper.log
+RUN ln -s /dev/stdout /var/log/ignition/wrapper.log && \
+    chown -h ${IGNITION_UID}:${IGNITION_GID} /var/log/ignition/wrapper.log
 
 # Declare Healthcheck
 HEALTHCHECK --interval=10s --start-period=60s --timeout=3s \

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -311,9 +311,9 @@ check_for_upgrade() {
                 "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx" \
                 "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             ln -s "${DATA_VOLUME_LOCATION}" "${IGNITION_INSTALL_LOCATION}/data"
-            ln -s "${DATA_VOLUME_LOCATION}/metro-keystore" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
-            ln -s "${DATA_VOLUME_LOCATION}/csr.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx"
-            ln -s "${DATA_VOLUME_LOCATION}/ssl.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
+            ln -s "${DATA_VOLUME_LOCATION}/local/metro-keystore" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
+            ln -s "${DATA_VOLUME_LOCATION}/local/csr.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx"
+            ln -s "${DATA_VOLUME_LOCATION}/local/ssl.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             # Drop another symbolic link in original location for compatibility
             rm -rf /var/lib/ignition/data
             ln -s "${DATA_VOLUME_LOCATION}" /var/lib/ignition/data
@@ -328,9 +328,9 @@ check_for_upgrade() {
                 "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx" \
                 "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             ln -s "${DATA_VOLUME_LOCATION}" "${IGNITION_INSTALL_LOCATION}/data"
-            ln -s "${DATA_VOLUME_LOCATION}/metro-keystore" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
-            ln -s "${DATA_VOLUME_LOCATION}/csr.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx"
-            ln -s "${DATA_VOLUME_LOCATION}/ssl.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
+            ln -s "${DATA_VOLUME_LOCATION}/local/metro-keystore" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
+            ln -s "${DATA_VOLUME_LOCATION}/local/csr.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx"
+            ln -s "${DATA_VOLUME_LOCATION}/local/ssl.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             # Remove the in-image data folder (that presumably is still fresh, extra safety check here)
             # and place a symbolic link to the /data volume for compatibility
             if [ ! -a "/var/lib/ignition/data/db/config.idb" ]; then

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -306,9 +306,13 @@ check_for_upgrade() {
             # Move in-image data volume contents to /data to seed the volume
             cp -Ru --preserve=links "${IGNITION_INSTALL_LOCATION}/data/"* "${DATA_VOLUME_LOCATION}/"
             # Replace symbolic links in base install location
-            rm "${IGNITION_INSTALL_LOCATION}/data" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
+            rm "${IGNITION_INSTALL_LOCATION}/data" \
+                "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore" \
+                "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             ln -s "${DATA_VOLUME_LOCATION}" "${IGNITION_INSTALL_LOCATION}/data"
             ln -s "${DATA_VOLUME_LOCATION}/metro-keystore" "${IGNITION_INSTALL_LOCATION}/webserver/metro-keystore"
+            ln -s "${DATA_VOLUME_LOCATION}/csr.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/csr.pfx"
+            ln -s "${DATA_VOLUME_LOCATION}/ssl.pfx" "${IGNITION_INSTALL_LOCATION}/webserver/ssl.pfx"
             # Drop another symbolic link in original location for compatibility
             rm -rf /var/lib/ignition/data
             ln -s "${DATA_VOLUME_LOCATION}" /var/lib/ignition/data

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -402,6 +402,8 @@ check_for_upgrade() {
                 ;;
         esac
     fi
+
+    chown "${IGNITION_UID}:${IGNITION_GID}" "${init_file_path}"
 }
 
 # Only collect additional arguments if we're not running a shell
@@ -534,7 +536,7 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
         for opt in "${JVM_OPTIONS[@]}"; do
             printf "%s\n" "${opt}" >> "${jvm_args_filepath}"
         done
-
+        chown "${IGNITION_UID}:${IGNITION_GID}" "${jvm_args_filepath}"
         WRAPPER_OPTIONS+=( "wrapper.java.additional_file=${jvm_args_filepath}" )
     fi
 


### PR DESCRIPTION
These changes add persisting of the SSL keystores (`ssl.pfx` and `csr.pfx`) used when enabling HTTPS on the gateway.  These will now be routed to `data/local` folder within the [typically] persisted volume location.  Upstream changes now support disabling SSL from the gateway webpage via removing the keystore _through_ the symlink.