### PR TITLE
Add initial `-slim` image support

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -6,7 +6,7 @@ ARG IGNITION_RC_VERSION=""
 # Default Build Edition - STABLE or NIGHTLY
 ARG BUILD_EDITION="STABLE"
 
-FROM ubuntu:latest AS downloader
+FROM ubuntu:20.04 AS downloader
 LABEL maintainer="Kevin Collins <kcollins@purelinux.net>"
 ARG IGNITION_VERSION
 ARG BUILD_EDITION
@@ -82,10 +82,17 @@ RUN set -exo pipefail; \
     fi; \
     chmod a+x "gosu"
 
+# Zip File Exclusion Build Argument
+ARG ZIP_EXCLUSION_RESOURCE_LIST
+ARG ZIP_EXCLUSION_MODULE_LIST
+ARG ZIP_EXCLUSION_ARCHITECTURE_LIST
+
 # Extract Installation Zip File
-RUN mkdir ignition && \
-    unzip -q ${INSTALLER_NAME} -d ignition/ && \
-    chmod +x ignition/ignition-gateway ignition/*.sh
+COPY extract-zip.sh .
+RUN ./extract-zip.sh -f "${INSTALLER_NAME}" \
+    "${ZIP_EXCLUSION_RESOURCE_LIST:+-xr}" "${ZIP_EXCLUSION_RESOURCE_LIST}" \
+    "${ZIP_EXCLUSION_MODULE_LIST+:-xm}" "${ZIP_EXCLUSION_MODULE_LIST}" \
+    "${ZIP_EXCLUSION_ARCHITECTURE_LIST:+-xa}" "${ZIP_EXCLUSION_ARCHITECTURE_LIST}"
 
 # Change to Ignition folder
 WORKDIR ${INSTALLER_PATH}/ignition

--- a/8.1/Makefile
+++ b/8.1/Makefile
@@ -27,7 +27,6 @@ include ../.env
 .build-full-rc:
 	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
 		echo "======== BUILDING IGNITION RELEASE CANDIDATE IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"; \
-		$(IGNITION_VERSION_CHECK) \
 		docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
 		--build-arg BUILD_EDITION=RC \
 		-t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} -f Dockerfile .; \
@@ -38,7 +37,6 @@ include ../.env
 .build-slim-rc:
 	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
 		echo "======== BUILDING IGNITION RELEASE CANDIDATE SLIM IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"; \
-		$(IGNITION_VERSION_CHECK) \
 		docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
 		--build-arg BUILD_EDITION=RC \
 		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \

--- a/8.1/Makefile
+++ b/8.1/Makefile
@@ -8,62 +8,155 @@ IGNITION_RC_VERSION:=$$(grep -Po '(?<=IGNITION_RC_VERSION=\")((\d\.){2}\d+-rc\d)
 # Pull in base options (if called from this directory)
 include ../.env
 
-.build:
+.build-full:
 	@echo "======== BUILDING IGNITION IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"
 	$(IGNITION_VERSION_CHECK)
-	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=STABLE -t ${BASE_IMAGE_NAME}:${IGNITION_VERSION} -f Dockerfile .
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=STABLE \
+		-t ${BASE_IMAGE_NAME}:${IGNITION_VERSION} -f Dockerfile .
 
-.build-rc:
+.build-slim:
+	@echo "======== BUILDING IGNITION SLIM IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"
+	$(IGNITION_VERSION_CHECK)
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=STABLE \
+		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+		--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \
+		-t ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim -f Dockerfile .
+
+.build-full-rc:
 	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
 		echo "======== BUILDING IGNITION RELEASE CANDIDATE IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"; \
 		$(IGNITION_VERSION_CHECK) \
-		docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=RC -t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} -f Dockerfile .; \
+		docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=RC \
+		-t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} -f Dockerfile .; \
 	else \
 		echo "======== SKIPPING IGNITION RELEASE CANDIDATE IMAGE (SINGLE ARCHITECTURE) ========"; \
 	fi
 
-.build-nightly:
+.build-slim-rc:
+	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
+		echo "======== BUILDING IGNITION RELEASE CANDIDATE SLIM IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"; \
+		$(IGNITION_VERSION_CHECK) \
+		docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=RC \
+		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+		--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \
+		-t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION}-slim -f Dockerfile .; \
+	else \
+		echo "======== SKIPPING IGNITION RELEASE CANDIDATE IMAGE (SINGLE ARCHITECTURE) ========"; \
+	fi
+
+.build-full-nightly:
 	@echo "======== BUILDING IGNITION NIGHTLY IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"
 	$(IGNITION_VERSION_CHECK)
-	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=NIGHTLY -t ${BASE_IMAGE_NAME}:nightly -f Dockerfile .
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=NIGHTLY \	
+		-t ${BASE_IMAGE_NAME}:nightly -f Dockerfile .
 
-.multibuild: CACHE_TAG=cache-${IGNITION_VERSION}
-.multibuild:
+.build-slim-nightly:
+	@echo "======== BUILDING IGNITION NIGHTLY SLIM IMAGE LOCALLY (SINGLE ARCHITECTURE) ========"
+	$(IGNITION_VERSION_CHECK)
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=NIGHTLY \
+		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+		--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \		
+		-t ${BASE_IMAGE_NAME}:nightly-slim -f Dockerfile .
+
+.multibuild-full: CACHE_TAG=cache-${IGNITION_VERSION}
+.multibuild-full:
 	@echo "======== BUILDING IGNITION IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"
 	$(IGNITION_VERSION_CHECK)
-	docker buildx build ${DOCKER_BUILDX_CACHE_OPTS} ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=STABLE -t ${BASE_IMAGE_NAME}:${IGNITION_VERSION} --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
+	docker buildx build ${DOCKER_BUILDX_CACHE_OPTS} ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=STABLE \
+		-t ${BASE_IMAGE_NAME}:${IGNITION_VERSION} --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
 	docker buildx imagetools create ${BASE_IMAGE_NAME}:${IGNITION_VERSION} --tag ${BASE_IMAGE_NAME}:8.1
 	docker buildx imagetools create ${BASE_IMAGE_NAME}:${IGNITION_VERSION} --tag ${BASE_IMAGE_NAME}:latest
 
-.multibuild-rc:
+.multibuild-slim: CACHE_TAG=cache-${IGNITION_VERSION}-slim
+.multibuild-slim:
+	@echo "======== BUILDING IGNITION SLIM IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"
+	$(IGNITION_VERSION_CHECK)
+	docker buildx build ${DOCKER_BUILDX_CACHE_OPTS} ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=STABLE \
+		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+		--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \		
+		-t ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
+	docker buildx imagetools create ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim --tag ${BASE_IMAGE_NAME}:8.1-slim
+	docker buildx imagetools create ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim --tag ${BASE_IMAGE_NAME}:latest-slim
+
+.multibuild-full-rc:
 	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
 		echo "======== BUILDING IGNITION RELEASE CANDIDATE IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"; \
-		docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=RC -t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push; \
+		docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+			--build-arg BUILD_EDITION=RC \
+			-t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push; \
 	else \
 		echo "======== SKIPPING IGNITION RELEASE CANDIDATE IMAGE (MULTI ARCHITECTURE) ========"; \
 	fi
 
-.multibuild-nightly:
+.multibuild-slim-rc:
+	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
+		echo "======== BUILDING IGNITION RELEASE CANDIDATE SLIM IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"; \
+		docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+			--build-arg BUILD_EDITION=RC \
+			--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+			--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \	
+			-t ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION}-slim --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push; \
+	else \
+		echo "======== SKIPPING IGNITION RELEASE CANDIDATE IMAGE (MULTI ARCHITECTURE) ========"; \
+	fi
+
+.multibuild-full-nightly:
 	@echo "======== BUILDING IGNITION NIGHTLY IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"
-	docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} --build-arg BUILD_EDITION=NIGHTLY -t ${BASE_IMAGE_NAME}:nightly --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
+	docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=NIGHTLY \
+		-t ${BASE_IMAGE_NAME}:nightly --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
+
+.multibuild-slim-nightly:
+	@echo "======== BUILDING IGNITION NIGHTLY SLIM IMAGE AND PUSHING TO REGISTRY (MULTI ARCHITECTURE) ========"
+	docker buildx build ${DOCKER_BUILDX_OPTS} ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} \
+		--build-arg BUILD_EDITION=NIGHTLY \
+		--build-arg ZIP_EXCLUSION_RESOURCE_LIST=designerlauncher,perspectiveworkstation,visionclientlauncher \
+		--build-arg ZIP_EXCLUSION_ARCHITECTURE_LIST=mac,linux64,win64 \	
+		-t ${BASE_IMAGE_NAME}:nightly-slim --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
 
 .push-registry:
 	@echo "======== PUSHING AND TAGGING IMAGES TO REGISTRY ========"
 	docker push ${BASE_IMAGE_NAME}:${IGNITION_VERSION}
+	docker push ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim
 	docker tag ${BASE_IMAGE_NAME}:${IGNITION_VERSION} ${BASE_IMAGE_NAME}:8.1
+	docker tag ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim ${BASE_IMAGE_NAME}:8.1-slim
 	docker push ${BASE_IMAGE_NAME}:8.1
+	docker push ${BASE_IMAGE_NAME}:8.1-slim
 	docker tag ${BASE_IMAGE_NAME}:${IGNITION_VERSION} ${BASE_IMAGE_NAME}:latest
+	docker tag ${BASE_IMAGE_NAME}:${IGNITION_VERSION}-slim ${BASE_IMAGE_NAME}:latest-slim
 	docker push ${BASE_IMAGE_NAME}:latest
+	docker push ${BASE_IMAGE_NAME}:latest-slim
 	@if [[ -n "${IGNITION_RC_VERSION}" ]]; then \
 		docker push ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION} \
+		docker push ${BASE_IMAGE_NAME}:${IGNITION_RC_VERSION}-slim \
 	fi
 
 ### BUILD TARGETS ###
 all:
-	@echo "Please specify a build target: build, multibuild, build-rc, multibuild-rc, build-nightly, multibuild-nightly"
-build: .build
-build-rc: .build-rc
-build-nightly: .build-nightly
-multibuild: .multibuild
-multibuild-rc: .multibuild-rc
-multibuild-nightly: .multibuild-nightly
+	@echo "Please specify a build target: [build | multibuild][-full | -slim][-rc | -nightly]"
+build: .build-full .build-slim
+build-full: .build-full
+build-slim: .build-slim
+build-rc: .build-full-rc .build-slim-rc
+build-full-rc: .build-full-rc
+build-slim-rc: .build-slim-rc
+build-nightly: .build-full-nightly .build-slim-nightly
+build-full-nightly: .build-full-nightly
+build-slim-nightly: .build-slim-nightly
+multibuild: .multibuild-full .multibuild-slim
+multibuild-full: .multibuild-full
+multibuild-slim: .multibuild-slim
+multibuild-rc: .multibuild-full-rc .multibuild-slim-rc
+multibuild-full-rc: .multibuild-full-rc
+multibuild-slim-rc: .multibuild-slim-rc
+multibuild-nightly: .multibuild-full-nightly .multibuild-slim-nightly
+multibuild-full-nightly: .multibuild-full-nightly
+multibuild-slim-nightly: .multibuild-slim-nightly

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 shopt -s nullglob
 if [[ "${ENTRYPOINT_DEBUG_ENABLED}" = "true" ]]; then set -x; fi
@@ -497,6 +497,17 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
             "-Xdebug"
             "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000"
         )
+    fi
+
+    # Add hosted launchers option when launchers are absent from the filesystem
+    declare launch_files=( 
+        "${IGNITION_INSTALL_LOCATION}lib/core/launch/perspectiveworkstation."*
+        "${IGNITION_INSTALL_LOCATION}lib/core/launch/visionclientlauncher."*
+        "${IGNITION_INSTALL_LOCATION}lib/core/launch/designerlauncher."*
+    )
+    if (( ${#launch_files[@]} == 0 )); then
+        echo "init     | Launchers absent from image, enabling hosted launchers."
+        JVM_OPTIONS+=( "-Dignition.hostedLaunchers=true" )
     fi
 
     # Collect JVM Arguments

--- a/8.1/extract-zip.sh
+++ b/8.1/extract-zip.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+declare LAUNCHER_PATH="lib/core/launch"
+declare MODULE_PATH="user-lib/modules"
+declare -a ZIP_EXCLUSION_MODULE_LIST
+declare -a ZIP_EXCLUSION_ARCHITECTURE_LIST
+declare -a ZIP_EXCLUSION_RESOURCE_LIST
+declare -A ZIP_EXCLUSION_MODULE_CHOICES=(
+    ["alarm-notification"]="${MODULE_PATH}/Alarm Notification-module.modl"
+    ["allen-bradley-drivers"]="${MODULE_PATH}/Allen-Bradley Drivers-module.modl"
+    ["bacnet-driver"]="${MODULE_PATH}/BACnet Driver-module.modl"
+    ["dnp3-driver"]="${MODULE_PATH}/DNP3-Driver.modl"
+    ["enterprise-administration"]="${MODULE_PATH}/Enterprise Administration-module.modl"
+    ["logix-driver"]="${MODULE_PATH}/Logix Driver-module.modl"
+    ["mobile-module"]="${MODULE_PATH}/Mobile-module.modl"
+    ["modbus-driver-v2"]="${MODULE_PATH}/Modbus Driver v2-module.modl"
+    ["omron-driver"]="${MODULE_PATH}/Omron-Driver.modl"
+    ["opc-ua"]="${MODULE_PATH}/OPC-UA-module.modl"
+    ["perspective"]="${MODULE_PATH}/Perspective-module.modl"
+    ["reporting"]="${MODULE_PATH}/Reporting-module.modl"
+    ["serial-support-client"]="${MODULE_PATH}/Serial Support Client-module.modl"
+    ["serial-support-gateway"]="${MODULE_PATH}/Serial Support Gateway-module.modl"
+    ["sfc"]="${MODULE_PATH}/SFC-module.modl"
+    ["siemens-drivers"]="${MODULE_PATH}/Siemens Drivers-module.modl"
+    ["sms-notification"]="${MODULE_PATH}/SMS Notification-module.modl"
+    ["sql-bridge"]="${MODULE_PATH}/SQL Bridge-module.modl"
+    ["symbol-factory"]="${MODULE_PATH}/Symbol Factory-module.modl"
+    ["tag-historian"]="${MODULE_PATH}/Tag Historian-module.modl"
+    ["udp-tcp-drivers"]="${MODULE_PATH}/UDP and TCP Drivers-module.modl"
+    ["user-manual"]="${MODULE_PATH}/User Manual-module.modl"
+    ["vision"]="${MODULE_PATH}/Vision-module.modl"
+    ["voice-notification"]="${MODULE_PATH}/Voice Notification-module.modl"
+    ["web-browser"]="${MODULE_PATH}/Web Browser Module.modl"
+    ["web-developer"]="${MODULE_PATH}/Web Developer Module.modl"
+)
+declare -a ZIP_EXCLUSION_RESOURCE_CHOICES=(
+    "designerlauncher"
+    "perspectiveworkstation"
+    "visionclientlauncher"
+    "jxbrowser"
+)
+declare -A ZIP_EXCLUSION_ARCHITECTURE_CHOICES=(
+    ["mac"]=".dmg"
+    ["linux64"]=".tar.gz"
+    ["win64"]=".exe"
+)
+declare -A ZIP_EXCLUSION_RESOURCEARCH_CHOICES
+for resource in "${ZIP_EXCLUSION_RESOURCE_CHOICES[@]}"; do
+    for arch in "${!ZIP_EXCLUSION_ARCHITECTURE_CHOICES[@]}"; do
+        file_extension="${ZIP_EXCLUSION_ARCHITECTURE_CHOICES[${arch}]}"
+        ZIP_EXCLUSION_RESOURCEARCH_CHOICES["${resource}-${arch}"]="${LAUNCHER_PATH}/${resource}${file_extension}"
+    done
+done
+
+function main() {
+    local -a module_exclusion_list
+    local -a resource_exclusion_list
+    local extraction_base_path="ignition"
+    local resource_exclusion resource_target module_exclusion module_target
+    local -a zip_exclusion_architecture_list
+
+    # Gather up file exclusions for modules
+    for module in "${ZIP_EXCLUSION_MODULE_LIST[@]}"; do
+        module_target="${module// }"
+        module_exclusion="${ZIP_EXCLUSION_MODULE_CHOICES[${module_target}]}"
+        if [[ -n "${module_exclusion}" ]]; then
+            module_exclusion_list+=("${module_exclusion}")
+        fi
+    done
+
+    # Gather up file exclusions for resource, by-architecture
+    if [[ -z "${ZIP_EXCLUSION_ARCHITECTURE_LIST[*]}" ]]; then
+        zip_exclusion_architecture_list=("${!ZIP_EXCLUSION_ARCHITECTURE_CHOICES[@]}")
+    else
+        zip_exclusion_architecture_list=("${ZIP_EXCLUSION_ARCHITECTURE_LIST[@]}")
+    fi
+
+    for arch in "${zip_exclusion_architecture_list[@]}"; do
+        for resource in "${ZIP_EXCLUSION_RESOURCE_LIST[@]}"; do
+            resource_target="${resource// }-${arch}"
+            resource_exclusion="${ZIP_EXCLUSION_RESOURCEARCH_CHOICES[${resource_target}]}"
+            if [[ -n "${resource_exclusion}" ]]; then
+                resource_exclusion_list+=("${resource_exclusion}")
+            fi
+        done
+    done
+
+    # mkdir -p "${extraction_base_path}"
+    eval ${DEBUG:+echo} unzip -q "${INSTALLER_NAME}" -x "${module_exclusion_list[@]}" "${resource_exclusion_list[@]}" -d "${extraction_base_path}/"
+    chmod +x "${extraction_base_path}/ignition-gateway" "${extraction_base_path}/"*.sh
+}
+
+PARAMS=""
+
+function storeArg() {
+    local arg_name="$1"
+    local arg_value="$2"
+    local arg_delimiter="${3:-}"
+    declare -n arg_ptr="$1"
+
+    if [ -n "${arg_value}" ] && [ "${arg_value:0:1}" != "-" ]; then
+        if [ -n "${arg_delimiter}" ]; then
+            IFS="${arg_delimiter}"; read -ra arg_ptr <<< "${arg_value}"
+        else
+            # shellcheck disable=SC2178,SC2034
+            arg_ptr="${arg_value}"
+        fi
+    else
+        echo "Error: missing argument for '${arg_name}'"
+        exit 1
+    fi
+}
+
+# Collect and Process Arguments
+while (( "$#" )); do
+    case "$1" in
+        -f|--installer-file)
+            storeArg "INSTALLER_NAME" "$2"
+            shift 2
+            ;;
+        -xr|--exclude-resources)
+            storeArg "ZIP_EXCLUSION_RESOURCE_LIST" "$2" ","
+            shift 2
+            ;;
+        -xm|--exclude-modules)
+            storeArg "ZIP_EXCLUSION_MODULE_LIST" "$2" ","
+            shift 2
+            ;;
+        -xa|--exclude-architectures)
+            storeArg "ZIP_EXCLUSION_ARCHITECTURE_LIST" "$2" ","
+            shift 2
+            ;;  
+        -d|--debug)
+            storeArg "DEBUG" "1"
+            shift 1
+            ;;
+        --*=|-*) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        *) # preserve positional arguments
+            PARAMS="${PARAMS} $1"
+            shift
+            ;;
+    esac
+done
+
+# Usage Help
+if [[ -z "${INSTALLER_NAME:-}" ]]; then
+    echo "Usage: extract-zip.sh -f <INSTALLER_PATH>"
+    echo "                     [-xr <EXCLUDED_RESOURCE>,...]"
+    echo "                     [-xm <EXCLUDED_MODULE>,...]"
+    echo "                     [-xa <EXCLUDED_ARCHITECTURE>,...]"
+    echo "                     [-d | --debug]"
+    echo ""
+    echo "Where:"
+    echo "<EXCLUDED_RESOURCE> is one of:"
+    for resource in "${ZIP_EXCLUSION_RESOURCE_CHOICES[@]}"; do printf "    %q\n" "${resource}"; done
+    echo ""
+    echo "<EXCLUDED_MODULE> is one of:"
+    for module in "${!ZIP_EXCLUSION_MODULE_CHOICES[@]}"; do printf "    %q\n" "${module}"; done
+    echo ""
+    echo "<EXCLUDED_ARCHITECURE> is one of:"
+    for arch in "${!ZIP_EXCLUSION_ARCHITECTURE_CHOICES[@]}"; do printf "    %q\n" "${arch}"; done
+    exit 1
+fi
+
+# set positional arguments in their proper place
+eval set -- "${PARAMS}"
+
+main

--- a/8.1/perform-commissioning.sh
+++ b/8.1/perform-commissioning.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 port="${GATEWAY_HTTP_PORT:-8088}"
 

--- a/8.1/register-jdbc.sh
+++ b/8.1/register-jdbc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
 shopt -s inherit_errexit

--- a/8.1/register-modules.sh
+++ b/8.1/register-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
 shopt -s inherit_errexit


### PR DESCRIPTION
### Background

By default, Ignition includes Designer Launcher, Vision Client Launcher, and Perspective Workstation for all three supported platforms--Linux x86_64, Windows 64-bit, and macOS x86_64.  This results in quite a lot of extra space occupied in the image.  

This PR adds functionality in the new `extract-zip.sh` shell script (that handles extracting the Ignition .zip installer) to exclude certain resources/modules from the build.

The Makefile adds new `-full` and `-slim` options (where the existing ones fire off both full and slim builds).  The `-slim` tags will exclude Designer Launcher, Vision Client Launcher, and Perspective Workstation resources and automatically enable [the hosted launchers feature](https://docs.inductiveautomation.com/display/DOC81/Launchers+and+Workstation#LaunchersandWorkstation-HostedLauncherInstallers) within the gateway to stream these resources from the public internet.  

