### PR TITLE
Updated for Ignition 7.9.19

### DIFF
--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -152,8 +152,7 @@ WORKDIR ${IGNITION_INSTALL_LOCATION}
 ENV PATH="${IGNITION_INSTALL_LOCATION}/lib/runtime/jre/bin:${PATH}"
 
 # Copy in Entrypoint and helper scripts
-COPY docker-entrypoint.sh /usr/local/bin/
-COPY accept-gwnetwork.sh /usr/local/bin/
+COPY *.sh /usr/local/bin/
 
 STOPSIGNAL SIGINT
 

--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -87,7 +87,9 @@ LABEL maintainer "Kevin Collins <kcollins@purelinux.net>"
 ARG IGNITION_VERSION
 
 # Install some prerequisite packages
-RUN apt-get update && apt-get install -y curl gettext procps pwgen zip unzip sqlite3 fontconfig fonts-dejavu libatomic1
+RUN apt-get update && \
+    apt-get install -y curl gettext procps pwgen zip unzip sqlite3 fontconfig fonts-dejavu libatomic1 tini && \
+    rm -rf /var/lib/apt/lists/*
 
 # Setup Install Targets
 ENV IGNITION_INSTALL_LOCATION="/usr/local/share/ignition"
@@ -129,6 +131,8 @@ ENV PATH="${IGNITION_INSTALL_LOCATION}/lib/runtime/jre/bin:${PATH}"
 # Copy in Entrypoint and helper scripts
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY accept-gwnetwork.sh /usr/local/bin/
+
+STOPSIGNAL SIGINT
 
 # Prepare Execution Settings
 ENTRYPOINT [ "docker-entrypoint.sh" ]

--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -104,7 +104,7 @@ RUN set -exo pipefail; \
     fi
 
 # RUNTIME IMAGE
-FROM adoptopenjdk:8-jre-hotspot-bionic as final
+FROM eclipse-temurin:8-jre-focal as final
 LABEL maintainer "Kevin Collins <kcollins@purelinux.net>"
 ARG IGNITION_VERSION
 

--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -21,6 +21,15 @@ ARG IGNITION_EDGE_ARMHF_DOWNLOAD_URL="https://files.inductiveautomation.com/rele
 ARG IGNITION_EDGE_ARMHF_DOWNLOAD_SHA256="176dc1e86f6719b80b6907ca6833ee4b83d9d1f9e7cdd2fd1dc58b9d4fd38d0a"
 ARG IGNITION_ARMHF_JRE_SUFFIX="arm32hf"
 
+# gosu Download Parameters
+ARG GOSU_VERSION="1.14"
+ARG GOSU_AMD64_DOWNLOAD_URL="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"
+ARG GOSU_AMD64_DOWNLOAD_SHA256="bd8be776e97ec2b911190a82d9ab3fa6c013ae6d3121eea3d0bfd5c82a0eaf8c"
+ARG GOSU_ARMHF_DOWNLOAD_URL="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-armhf"
+ARG GOSU_ARMHF_DOWNLOAD_SHA256="abb1489357358b443789571d52b5410258ddaca525ee7ac3ba0dd91d34484589"
+ARG GOSU_ARM64_DOWNLOAD_URL="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-arm64"
+ARG GOSU_ARM64_DOWNLOAD_SHA256="73244a858f5514a927a0f2510d533b4b57169b64d2aa3f9d98d92a7a7df80cea"
+
 # Default Build Edition - FULL, EDGE
 ARG BUILD_EDITION="FULL"
 
@@ -45,6 +54,19 @@ RUN set -exo pipefail; \
         exit 1; \
     fi
 
+# Download gosu based on Detected Architecture
+RUN set -exo pipefail; \
+    dpkg_arch="$(dpkg --print-architecture | awk '{print toupper($0)}')"; \
+    download_url_env="GOSU_${dpkg_arch}_DOWNLOAD_URL"; \
+    download_sha256_env="GOSU_${dpkg_arch}_DOWNLOAD_SHA256"; \
+    if [[ -n "${!download_url_env}" ]] && [[ -n "${!download_sha256_env}" ]]; then \
+    wget -q --ca-certificate=/etc/ssl/certs/ca-certificates.crt -O "gosu" "${!download_url_env}" && \
+    echo "${!download_sha256_env}" "gosu" | sha256sum -c -; \
+    else \
+    echo "Architecture ${dpkg_arch} download targets for gosu not defined, aborting build"; \
+    exit 1; \
+    fi; \
+    chmod a+x "gosu"
 
 # Extract Installation Zip File
 RUN mkdir ignition && \
@@ -111,6 +133,7 @@ RUN mkdir ${IGNITION_INSTALL_USERHOME} && \
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /root/ignition ${IGNITION_INSTALL_LOCATION}
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/lib/ignition /var/lib/ignition
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/log/ignition /var/log/ignition
+COPY --from=downloader /root/gosu /usr/local/bin/
 RUN ln -s /dev/stdout /var/log/ignition/wrapper.log && \
     chown -h ${IGNITION_UID}:${IGNITION_GID} /var/log/ignition/wrapper.log
 
@@ -122,7 +145,7 @@ HEALTHCHECK --interval=10s --start-period=60s --timeout=3s \
 EXPOSE 8088 8043 8000
 
 # Launch Ignition
-USER ${IGNITION_UID}
+USER root
 WORKDIR ${IGNITION_INSTALL_LOCATION}
 
 # Update path to include embedded java install location

--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -1,5 +1,5 @@
 # Ignition Version
-ARG IGNITION_VERSION="7.9.18"
+ARG IGNITION_VERSION="7.9.19"
 
 FROM ubuntu:latest AS downloader
 LABEL maintainer "Kevin Collins <kcollins@purelinux.net>"
@@ -9,16 +9,16 @@ ARG IGNITION_VERSION
 RUN apt-get update && apt-get install -y wget unzip
 
 # Ignition Downloader Parameters
-ARG IGNITION_FULL_AMD64_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.18/20210629-1315/zip-installers/Ignition-linux-64-7.9.18.zip"
-ARG IGNITION_FULL_AMD64_DOWNLOAD_SHA256="edabae1df43db7d8c878c90bc623d8d6a5bdab6450960d30349166bb45b69470"
-ARG IGNITION_EDGE_AMD64_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.18/20210629-1315/zip-installers/Ignition-linux-64-7.9.18.zip"
-ARG IGNITION_EDGE_AMD64_DOWNLOAD_SHA256="edabae1df43db7d8c878c90bc623d8d6a5bdab6450960d30349166bb45b69470"
+ARG IGNITION_FULL_AMD64_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.19/20220315-0901/zip-installers/Ignition-linux-64-7.9.19.zip"
+ARG IGNITION_FULL_AMD64_DOWNLOAD_SHA256="557a45140c3c6eecdaa282d4f2cded7f2a3693287d79c232e87537cfd3eeb54c"
+ARG IGNITION_EDGE_AMD64_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.19/20220315-0901/zip-installers/Ignition-linux-64-7.9.19.zip"
+ARG IGNITION_EDGE_AMD64_DOWNLOAD_SHA256="557a45140c3c6eecdaa282d4f2cded7f2a3693287d79c232e87537cfd3eeb54c"
 ARG IGNITION_AMD64_JRE_SUFFIX="nix"
 
-ARG IGNITION_FULL_ARMHF_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.18/20210629-1315/zip-installers/Ignition-linux-armhf-7.9.18.zip"
-ARG IGNITION_FULL_ARMHF_DOWNLOAD_SHA256="c64e9c75130625c26710871ff1282aa748ffe8ee8280426762e24b48390fc9c7"
-ARG IGNITION_EDGE_ARMHF_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.18/20210629-1315/zip-installers/Ignition-Edge-linux-armhf-7.9.18.zip"
-ARG IGNITION_EDGE_ARMHF_DOWNLOAD_SHA256="1bf93fecdcf5845f2cd2878b020e40d349247b69869f028d8d2b24a87ddda95a"
+ARG IGNITION_FULL_ARMHF_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.19/20220315-0901/zip-installers/Ignition-linux-armhf-7.9.19.zip"
+ARG IGNITION_FULL_ARMHF_DOWNLOAD_SHA256="38c1b68395d71ca63e0bfa876875d30048264555d1d30a2e85e3e9fc7cd91c9a"
+ARG IGNITION_EDGE_ARMHF_DOWNLOAD_URL="https://files.inductiveautomation.com/release/ia/build7.9.19/20220315-0901/zip-installers/Ignition-Edge-linux-armhf-7.9.19.zip"
+ARG IGNITION_EDGE_ARMHF_DOWNLOAD_SHA256="176dc1e86f6719b80b6907ca6833ee4b83d9d1f9e7cdd2fd1dc58b9d4fd38d0a"
 ARG IGNITION_ARMHF_JRE_SUFFIX="arm32hf"
 
 # Default Build Edition - FULL, EDGE

--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -109,6 +109,8 @@ RUN mkdir ${IGNITION_INSTALL_USERHOME} && \
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /root/ignition ${IGNITION_INSTALL_LOCATION}
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/lib/ignition /var/lib/ignition
 COPY --chown=${IGNITION_UID}:${IGNITION_GID} --from=downloader /var/log/ignition /var/log/ignition
+RUN ln -s /dev/stdout /var/log/ignition/wrapper.log && \
+    chown -h ${IGNITION_UID}:${IGNITION_GID} /var/log/ignition/wrapper.log
 
 # Declare Healthcheck
 HEALTHCHECK --interval=10s --start-period=60s --timeout=3s \

--- a/7.9/accept-gwnetwork.sh
+++ b/7.9/accept-gwnetwork.sh
@@ -4,7 +4,7 @@ shopt -s nullglob
 DELAY=${1:-60}
 QUARANTINE=/var/lib/ignition/data/certificates/gateway_network/quarantine
 
-echo "Beginning automatic gateway network certificate acceptance (${DELAY}s)..."
+echo "init     | Beginning automatic gateway network certificate acceptance (${DELAY}s)..."
 
 for ((i=DELAY;i>0;i--)); do
     if [[ -d "${QUARANTINE}" ]]; then
@@ -18,4 +18,4 @@ for ((i=DELAY;i>0;i--)); do
     sleep 1
 done
 
-echo "Finished automatic gateway network certificate acceptance."
+echo "init     | Finished automatic gateway network certificate acceptance."

--- a/7.9/docker-entrypoint.sh
+++ b/7.9/docker-entrypoint.sh
@@ -434,6 +434,8 @@ check_for_upgrade() {
                 ;;
         esac
     fi
+
+    chown "${IGNITION_UID}:${IGNITION_GID}" "${init_file_path}"
 }
 
 # Collect additional arguments if we're running the gateway
@@ -569,6 +571,54 @@ if [ "$1" = './ignition-gateway' ]; then
 
     # Stage tini as init replacement
     set -- tini -g -- "${CMD[@]}"
+
+    # Check for running as root and adjust permissions as needed, then stage dropdown to `ignition` user for gateway launch.
+    if [ "$(id -u)" = "0" ] && [ "${IGNITION_UID}" != "0" ]; then
+        # Obtain ignition UID/GID
+        ignition_uid_current=$(id -u ignition)
+        ignition_gid_current=$(id -g ignition)
+
+        if [[ "${ignition_uid_current}" != "${IGNITION_UID}" ]]; then
+            echo "init     | Adjusting UID of 'ignition' user from ${ignition_uid_current} to ${IGNITION_UID}"
+            usermod -u "${IGNITION_UID}" ignition
+        fi
+        if [[ "${ignition_gid_current}" != "${IGNITION_GID}" ]]; then
+            echo "init     | Adjusting GID of 'ignition' user from ${ignition_gid_current} to ${IGNITION_GID}"
+            groupmod -g "${IGNITION_GID}" ignition
+        fi
+
+        # Ensure permissions of stdout for logging
+        chown ignition:ignition logs/wrapper.log
+
+        # Adjust permissions of base Ignition paths
+        base_ignition_paths=(
+            "/var/lib/ignition"
+            "/var/log/ignition"
+        )
+        readarray -d '' pa_base_ignition_paths < <(find "${base_ignition_paths[@]}" -maxdepth 0 \! \( -user ignition -group ignition \) -print0)
+        if (( ${#pa_base_ignition_paths[@]} > 0 )); then
+            echo "init     | Adjusting permissions of base Ignition paths: ${pa_base_ignition_paths[*]}"
+            chown ignition:ignition "${base_ignition_paths[@]}"
+        fi
+
+        # Adjust permissions of Ignition install files
+        readarray -d '' pa_ignition_files < <(find -L "${IGNITION_INSTALL_LOCATION}" \! \( -user ignition -group ignition \) -a \! -name "wrapper.log" -print0)
+        if (( ${#pa_ignition_files[@]} > 0 )); then
+            echo "init     | Adjusting permissions of ${#pa_ignition_files[@]} Ignition installation files under '${IGNITION_INSTALL_LOCATION}', following symlinks..."
+            # ignore failures with '|| true' here due to potentially broken symlink to metro-keystore (fresh launch)
+            chown -f ignition:ignition "${pa_ignition_files[@]}" || true
+        fi
+
+        # Adjust permissions of symlinks within Ignition install files
+        readarray -d '' pa_ignition_symlinks < <(find "${IGNITION_INSTALL_LOCATION}" "${base_ignition_paths[@]}" -type l \! \( -user ignition -group ignition \) -print0)
+        if (( ${#pa_ignition_symlinks[@]} > 0 )); then
+            echo "init     | Fine-tuning permissions of ${#pa_ignition_symlinks[@]} symlinks under: ${IGNITION_INSTALL_LOCATION} ${base_ignition_paths[*]}"
+            chown -h ignition:ignition "${pa_ignition_symlinks[@]}"
+        fi
+
+        echo "init     | Staging user step-down from 'root' to 'ignition'"
+        set -- gosu ignition "$@"
+    fi
 
     echo 'Starting Ignition Gateway...'
 fi

--- a/7.9/docker-entrypoint.sh
+++ b/7.9/docker-entrypoint.sh
@@ -5,7 +5,11 @@ shopt -s nullglob
 # Local initialization
 INIT_FILE=/usr/local/share/ignition/data/init.properties
 CMD=( "$@" )
-WRAPPER_OPTIONS=( )
+WRAPPER_OPTIONS=(
+    "wrapper.console.loglevel=NONE"
+    "wrapper.logfile.format=PTM"
+    "wrapper.logfile.rollmode=NONE"
+)
 JAVA_OPTIONS=( )
 GATEWAY_MODULE_RELINK=${GATEWAY_MODULE_RELINK:-false}
 GATEWAY_JDBC_RELINK=${GATEWAY_JDBC_RELINK:-false}

--- a/7.9/docker-entrypoint.sh
+++ b/7.9/docker-entrypoint.sh
@@ -112,74 +112,6 @@ stop_process() {
     fi
 }
 
-# usage register_jdbc RELINK_ENABLED DB_LOCATION
-#   ie: register_jdbc true /var/lib/ignition/data/db/config.idb
-register_jdbc() {
-    if [ ! -d "/jdbc" ]; then
-        return 0  # Silently exit if there is no /jdbc path
-    else
-        echo "init     | Searching for third-party JDBC drivers..."
-    fi
-
-    local RELINK_ENABLED="${1:-false}"
-    local DB_LOCATION="${2}"
-    local SQLITE3=( sqlite3 "${DB_LOCATION}" )
-
-    # Get List of JDBC Drivers
-    mapfile -t JDBC_CLASSNAMES < <( "${SQLITE3[@]}" "SELECT CLASSNAME FROM JDBCDRIVERS;" )
-    JDBC_CLASSPATHS=( "${JDBC_CLASSNAMES[@]/.//}" )  # replace dots with slashes for the paths
-
-    # Remove Invalid Symbolic Links
-    find "${IGNITION_INSTALL_LOCATION}/user-lib/jdbc" -type l ! -exec test -e {} \; -exec echo "init     | Removing invalid symlink for {}" \; -exec rm {} \;
-
-    # Establish Symbolic Links for new jdbc drivers and tie into db
-    for jdbc in /jdbc/*.jar; do
-        local jdbc_basename jdbc_sourcepath jdbc_destpath jdbc_listing
-        jdbc_basename=$(basename "${jdbc}")
-        jdbc_sourcepath=${jdbc}
-        jdbc_destpath="${IGNITION_INSTALL_LOCATION}/user-lib/jdbc/${jdbc_basename}"
-        
-        if [ -h "${jdbc_destpath}" ]; then
-            echo "init     | Skipping Linked JDBC Driver: ${jdbc_basename}"
-            continue
-        fi
-
-        # Determine if jdbc driver is a candidate for linking based on searching
-        # the list of existing JDBC Classname entries gathered above.
-        jdbc_listing=$(unzip -l "${jdbc}")
-        for ((i=0; i<${#JDBC_CLASSPATHS[*]}; i++)); do
-            classpath=${JDBC_CLASSPATHS[i]}
-            classname=${JDBC_CLASSNAMES[i]}
-            case ${jdbc_listing} in
-                *$classpath*)
-                jdbc_targetclassname=$classname
-                break;;
-            esac
-        done
-
-        # If we didn't find a match, ...
-        if [ -z "${jdbc_targetclassname}" ]; then
-            continue  # ... skip to next JDBC driver in path
-        fi
-
-        if [ -e "${jdbc_destpath}" ]; then
-            if [ "${RELINK_ENABLED}" != true ]; then
-                echo "init     | Skipping existing JDBC driver: ${jdbc_basename}"
-                continue
-            fi
-            echo "init     | Relinking JDBC Driver: ${jdbc_basename}"
-            rm "${jdbc_destpath}"
-        else
-            echo "init     | Linking JDBC Driver: ${jdbc_basename}"
-        fi
-        ln -s "${jdbc_sourcepath}" "${jdbc_destpath}"
-
-        # Update JDBCDRIVERS table
-        echo "init     |   Updating JDBCDRIVERS table for classname ${jdbc_targetclassname}"
-        "${SQLITE3[@]}" "UPDATE JDBCDRIVERS SET JARFILE='${jdbc_basename}' WHERE CLASSNAME='${jdbc_targetclassname}'"
-    done
-}
-
 # usage enable_disable_modules MODULES_ENABLED
 #   ie: enable_disable_modules vision,opc-ua,sql-bridge
 enable_disable_modules() {
@@ -255,78 +187,6 @@ enable_disable_modules() {
 		fi
 	done
 	echo
-}
-
-# usage register_modules RELINK_ENABLED DB_LOCATION
-#   ie: register_modules true /var/lib/ignition/data/db/config.idb
-register_modules() {
-    if [ ! -d "/modules" ]; then
-        return 0  # Silently exit if there is no /modules path
-    else
-        echo "init     | Searching for third-party modules..."
-    fi
-
-    local RELINK_ENABLED="${1:-false}"
-    local DB_LOCATION="${2}"
-    local SQLITE3=( sqlite3 "${DB_LOCATION}" )
-
-    # Remove Invalid Symbolic Links
-    find "${IGNITION_INSTALL_LOCATION}/user-lib/modules" -type l ! -exec test -e {} \; -exec echo "Removing invalid symlink for {}" \; -exec rm {} \;
-
-    # Establish Symbolic Links for new modules and tie into db
-    for module in /modules/*.modl; do
-        local module_basename module_sourcepath module_destpath keytool
-        module_basename=$(basename "${module}")
-        module_sourcepath=${module}
-        module_destpath="${IGNITION_INSTALL_LOCATION}/user-lib/modules/${module_basename}"
-        keytool=$(which keytool)
-
-        if [ -h "${module_destpath}" ]; then
-            echo "init     | Skipping Linked Module: ${module_basename}"
-            continue
-        fi
-
-        if [ -e "${module_destpath}" ]; then
-            if [ "${RELINK_ENABLED}" != true ]; then
-                echo "init     | Skipping existing module: ${module_basename}"
-                continue
-            fi
-            echo "init     | Relinking Module: ${module_basename}"
-            rm "${module_destpath}"
-        else
-            echo "init     | Linking Module: ${module_basename}"
-        fi
-        ln -s "${module_sourcepath}" "${module_destpath}"
-
-        # Populate CERTIFICATES table
-        local cert_info thumbprint subject_name next_certificates_id thumbprint_already_exists
-        cert_info=$( unzip -qq -c "${module_sourcepath}" certificates.p7b | $keytool -printcert -v | head -n 9 )
-        thumbprint=$( echo "${cert_info}" | grep -A 2 "Certificate fingerprints" | grep SHA1 | cut -d : -f 2- | sed -e 's/\://g' | awk '{$1=$1;print tolower($0)}' )
-        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN=\K(.+)(?=, OU)' | sed -e 's/"//g' )
-        echo "init     |   Thumbprint: ${thumbprint}"
-        echo "init     |   Subject Name: ${subject_name}"
-        next_certificates_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(CERTIFICATES_ID)+1,1) FROM CERTIFICATES" )
-        thumbprint_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM CERTIFICATES WHERE lower(hex(THUMBPRINT)) = '${thumbprint}'" )
-        if [ "${thumbprint_already_exists}" != "1" ]; then
-            echo "init     |   Accepting Certificate as CERTIFICATES_ID=${next_certificates_id}"
-            "${SQLITE3[@]}" "INSERT INTO CERTIFICATES (CERTIFICATES_ID, THUMBPRINT, SUBJECTNAME) VALUES (${next_certificates_id}, x'${thumbprint}', '${subject_name}'); UPDATE SEQUENCES SET val=${next_certificates_id} WHERE name='CERTIFICATES_SEQ'"
-        else
-            echo "init     |   Thumbprint already found in CERTIFICATES table, skipping INSERT"
-        fi
-
-        # Populate EULAS table
-        local next_eulas_id license_crc32 module_id module_id_already_exists
-        next_eulas_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(EULAS_ID)+1,1) FROM EULAS" )
-        license_crc32=$( unzip -qq -c "${module_sourcepath}" license.html | gzip -c | tail -c8 | od -t u4 -N 4 -A n | cut -c 2- )
-        module_id=$( unzip -qq -c "${module_sourcepath}" module.xml | grep -oP '(?<=<id>).*(?=</id)' )
-        module_id_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM EULAS WHERE MODULEID='${module_id}' AND CRC=${license_crc32}" )
-        if [ "${module_id_already_exists}" != "1" ]; then
-            echo "init     |   Accepting License on your behalf as EULAS_ID=${next_eulas_id}"
-            "${SQLITE3[@]}" "INSERT INTO EULAS (EULAS_ID, MODULEID, CRC) VALUES (${next_eulas_id}, '${module_id}', ${license_crc32}); UPDATE SEQUENCES SET val=${next_eulas_id} WHERE name='EULAS_SEQ'"
-        else
-            echo "init     |   License EULA already found in EULAS table, skipping INSERT"
-        fi
-    done
 }
 
 # usage: compare_versions IMAGE_VERSION VOLUME_VERSION
@@ -561,10 +421,10 @@ if [ "$1" = './ignition-gateway' ]; then
     fi
 
     # Link Additional Modules and prepare Ignition database
-    register_modules "${GATEWAY_MODULE_RELINK}" "${IGNITION_INSTALL_LOCATION}/data/db/config.idb"
+    register-modules.sh "${GATEWAY_MODULE_RELINK}" "${IGNITION_INSTALL_LOCATION}/data/db/config.idb"
 
     # Link Additional JDBC Drivers and prepare Ignition database
-    register_jdbc "${GATEWAY_JDBC_RELINK}" "${IGNITION_INSTALL_LOCATION}/data/db/config.idb"
+    register-jdbc.sh "${GATEWAY_JDBC_RELINK}" "${IGNITION_INSTALL_LOCATION}/data/db/config.idb"
     
     # Perform module enablement/disablement
     enable_disable_modules "${GATEWAY_MODULES_ENABLED}"

--- a/7.9/docker-entrypoint.sh
+++ b/7.9/docker-entrypoint.sh
@@ -567,7 +567,10 @@ if [ "$1" = './ignition-gateway' ]; then
     # Perform module enablement/disablement
     enable_disable_modules "${GATEWAY_MODULES_ENABLED}"
 
+    # Stage tini as init replacement
+    set -- tini -g -- "${CMD[@]}"
+
     echo 'Starting Ignition Gateway...'
 fi
 
-exec "${CMD[@]}"
+exec "$@"

--- a/7.9/register-jdbc.sh
+++ b/7.9/register-jdbc.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+shopt -s inherit_errexit
+
+# usage register_jdbc RELINK_ENABLED DB_LOCATION
+#   ie: register_jdbc true /var/lib/ignition/data/db/config.idb
+RELINK_ENABLED="${1:-false}"
+DB_LOCATION="${2}"
+DB_FILE=$(basename "${DB_LOCATION}")
+
+function main() {
+    if [ ! -d "/jdbc" ]; then
+        return 0  # Silently exit if there is no /jdbc path
+    elif [ ! -f "${DB_LOCATION}" ]; then
+        echo "init     | WARNING: ${DB_FILE} not found, skipping jdbc registration"
+        return 0
+    fi
+
+    register_jdbc
+}
+
+function register_jdbc() {
+    local SQLITE3=( sqlite3 "${DB_LOCATION}" )
+    local jdbc_destbase="${IGNITION_INSTALL_LOCATION}/user-lib/jdbc"
+    
+    echo "init     | Searching for third-party JDBC drivers..."
+    
+    # Get List of JDBC Drivers
+    mapfile -t JDBC_CLASSNAMES < <( "${SQLITE3[@]}" "SELECT CLASSNAME FROM JDBCDRIVERS;" )
+    JDBC_CLASSPATHS=( "${JDBC_CLASSNAMES[@]//.//}" )  # replace dots with slashes for the paths
+
+    # Remove Invalid Symbolic Links
+    find "${jdbc_destbase}" -type l ! -exec test -e {} \; -exec echo "Removing invalid symlink for {}" \; -exec rm {} \;
+
+    # Correlate entries in db with files via classpath.  This JDBC_ORIGINAL array will be used to purge other JDBC jars
+    # from `${IGNITION_INSTALL_LOCATION}/user-lib/jdbc` that conflict with those we are linking in from `/jdbc`.
+    # This will help ensure that the desired JAR is loaded instead of others that may be lingering on the filesystem.
+    declare -A JDBC_ORIGINAL
+    for jdbc in "${IGNITION_INSTALL_LOCATION}"/user-lib/jdbc/*.jar; do
+        if [[ -h "${jdbc}" ]]; then
+            continue  # skip symlinks
+        fi
+        unzip_listing_file=$(mktemp /tmp/jdbc_unzip_listing-XXXXXX.txt)
+        unzip -l "${jdbc}" > "${unzip_listing_file}"
+        for classpath in ${JDBC_CLASSPATHS[*]}; do
+            if grep -Pq "\s+${classpath}\.class$" < "${unzip_listing_file}"; then
+                JDBC_ORIGINAL["${classpath}"]+="${JDBC_ORIGINAL["${classpath}"]:+|}${jdbc}"
+            fi
+        done
+        rm "${unzip_listing_file}"
+    done
+
+    # Establish Symbolic Links for new jdbc drivers and tie into db
+    for jdbc in /jdbc/*.jar; do
+        local jdbc_basename jdbc_sourcepath jdbc_destpath
+        jdbc_basename=$(basename "${jdbc}")
+        jdbc_sourcepath=${jdbc}
+        jdbc_destpath="${jdbc_destbase}/${jdbc_basename}"
+        
+        # If we already see a symbolic link at the destination, take no further actions on behalf of this
+        # JDBC JAR since we've presumably already done our work last time.
+        if [ -h "${jdbc_destpath}" ]; then
+            echo "init     | Skipping Linked JDBC Driver: ${jdbc_basename}"
+            continue
+        fi  # otherwise ...
+
+        # Determine if jdbc driver is an active candidate for linking based on searching
+        # the list of existing JDBC Classname entries gathered above.
+        # NOTE: if this fails to match, we'll still link the JAR so the user can configure
+        #       the driver in the Gateway webpage after startup.  
+        local jdbc_listing
+        jdbc_listing=$(unzip -l "${jdbc}")
+        for ((i=0; i<${#JDBC_CLASSPATHS[*]}; i++)); do
+            classpath=${JDBC_CLASSPATHS[i]}
+            classname=${JDBC_CLASSNAMES[i]}
+            case ${jdbc_listing} in
+                *$classpath*)
+                jdbc_targetclasspath=$classpath
+                jdbc_targetclassname=$classname
+                break;;
+            esac
+        done
+
+        # Perform the linking from `/jdbc` into `user-lib/jdbc`
+        if [ -e "${jdbc_destpath}" ]; then
+            if [ "${RELINK_ENABLED}" != true ]; then
+                echo "init     | Skipping existing JDBC driver: ${jdbc_basename}"
+                continue
+            fi
+            echo "init     | Relinking JDBC Driver: ${jdbc_basename}"
+            rm "${jdbc_destpath}"
+        else
+            echo "init     | Linking JDBC Driver: ${jdbc_basename}"
+        fi
+        ln -s "${jdbc_sourcepath}" "${jdbc_destpath}"
+
+        # If we didn't find a matching class path, we'll skip to the next JDBC driver here after linking
+        # so that the user can configure a JDBC driver against the freshly linked JAR.
+        if [ -z "${jdbc_targetclassname}" ]; then
+            continue  # ... skip to next JDBC driver in path
+        fi
+
+        # Remove built-in JDBC jars that conflict with our active linked-in versions (to ensure that the linked one is loaded)
+        set +u  # temporarily disable error on unbound variables since this next statement is a dynamic indirect
+        if [[ ${JDBC_ORIGINAL[${jdbc_targetclasspath}]} ]]; then
+            IFS='|' read -r -a jdbc_original_files <<< "${JDBC_ORIGINAL[${jdbc_targetclasspath}]}"
+            for f in ${jdbc_original_files[*]}; do
+                if [[ -f "$f" ]]; then
+                    echo "init     | Removing conflicting JDBC driver '$(basename "${f}")'"
+                    rm -f "$f"
+                fi
+            done
+        fi
+        set -u
+
+        # Update JDBCDRIVERS table
+        # NOTE:  this JARFILE field appears to only be used to delete the JAR file from the filesystem and doesn't control
+        #        which one is loaded.
+        echo "init     |  Updating JDBCDRIVERS table for classname ${jdbc_targetclassname}"
+        "${SQLITE3[@]}" "UPDATE JDBCDRIVERS SET JARFILE='${jdbc_basename}' WHERE CLASSNAME='${jdbc_targetclassname}'"
+    done
+}
+
+main

--- a/7.9/register-modules.sh
+++ b/7.9/register-modules.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+shopt -s inherit_errexit
+
+# usage register-modules.sh RELINK_ENABLED DB_LOCATION
+#   ie: register-modules.sh true /var/lib/ignition/data/db/config.idb
+RELINK_ENABLED="${1:-false}"
+DB_LOCATION="${2}"
+DB_FILE=$(basename "${DB_LOCATION}")
+
+function main() {
+    if [ ! -d "/modules" ]; then
+        return 0  # Silently exit if there is no /modules path
+    elif [ ! -f "${DB_LOCATION}" ]; then
+        echo "init     | WARNING: ${DB_FILE} not found, skipping module registration"
+        return 0
+    fi
+
+    register_modules
+}
+
+function register_modules() {
+    local SQLITE3=( sqlite3 "${DB_LOCATION}" )
+
+    echo "init     | Searching for third-party modules..."
+
+    # Remove Invalid Symbolic Links
+    find "${IGNITION_INSTALL_LOCATION}/user-lib/modules" -type l ! -exec test -e {} \; -exec echo "init     | Removing invalid symlink for {}" \; -exec rm {} \;
+
+    # Establish Symbolic Links for new modules and tie into db
+    for module in /modules/*.modl; do
+        local module_basename keytool module_sourcepath module_destpath
+        module_basename=$(basename "${module}")
+        module_sourcepath=${module}
+        module_destpath="${IGNITION_INSTALL_LOCATION}/user-lib/modules/${module_basename}"
+        keytool=$(which keytool)
+
+        if [ -h "${module_destpath}" ]; then
+            echo "init     | Skipping Linked Module: ${module_basename}"
+            continue
+        fi
+
+        if [ -e "${module_destpath}" ]; then
+            if [ "${RELINK_ENABLED}" != true ]; then
+                echo "init     | Skipping existing module: ${module_basename}"
+                continue
+            fi
+            echo "init     | Relinking Module: ${module_basename}"
+            rm "${module_destpath}"
+        else
+            echo "init     | Linking Module: ${module_basename}"
+        fi
+        ln -s "${module_sourcepath}" "${module_destpath}"
+
+        # Populate CERTIFICATES table
+        local cert_info subject_name thumbprint next_certificates_id thumbprint_already_exists
+        cert_info=$( unzip -qq -c "${module_sourcepath}" certificates.p7b | $keytool -printcert -v | head -n 9 ) 
+        thumbprint=$( echo "${cert_info}" | grep -A 2 "Certificate fingerprints" | grep SHA1 | cut -d : -f 2- | sed -e 's/\://g' | awk '{$1=$1;print tolower($0)}' ) 
+        echo "init     |  Thumbprint: ${thumbprint}"
+        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
+        echo "init     |  Subject Name: ${subject_name}"
+        next_certificates_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(CERTIFICATES_ID)+1,1) FROM CERTIFICATES" ) 
+        thumbprint_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM CERTIFICATES WHERE lower(hex(THUMBPRINT)) = '${thumbprint}'" )
+        if [ "${thumbprint_already_exists}" != "1" ]; then
+            echo "init     |  Accepting Certificate as CERTIFICATES_ID=${next_certificates_id}"
+            "${SQLITE3[@]}" "INSERT INTO CERTIFICATES (CERTIFICATES_ID, THUMBPRINT, SUBJECTNAME) VALUES (${next_certificates_id}, x'${thumbprint}', '${subject_name}'); UPDATE SEQUENCES SET val=${next_certificates_id} WHERE name='CERTIFICATES_SEQ'"
+        else
+            echo "init     |  Thumbprint already found in CERTIFICATES table, skipping INSERT"
+        fi
+
+        # Populate EULAS table
+        local next_eulas_id license_crc32 module_id module_id_already_exists
+        next_eulas_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(EULAS_ID)+1,1) FROM EULAS" ) 
+        license_filename=$( unzip -qq -c "${module_sourcepath}" module.xml | grep -oP '(?<=<license>).*(?=</license)' )
+        license_crc32=$( unzip -qq -c "${module_sourcepath}" "${license_filename}" | gzip -c | tail -c8 | od -t u4 -N 4 -A n | cut -c 2- ) 
+        module_id=$( unzip -qq -c "${module_sourcepath}" module.xml | grep -oP '(?<=<id>).*(?=</id)' ) 
+        module_id_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM EULAS WHERE MODULEID='${module_id}' AND CRC=${license_crc32}" )
+        if [ "${module_id_already_exists}" != "1" ]; then
+            echo "init     |  Accepting License on your behalf as EULAS_ID=${next_eulas_id}"
+            "${SQLITE3[@]}" "INSERT INTO EULAS (EULAS_ID, MODULEID, CRC) VALUES (${next_eulas_id}, '${module_id}', ${license_crc32}); UPDATE SEQUENCES SET val=${next_eulas_id} WHERE name='EULAS_SEQ'"
+        else
+            echo "init     |  License EULA already found in EULAS table, skipping INSERT"
+        fi
+    done
+}
+
+main

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 * [`8.1.15`, `8.1`, `latest`, `nightly`  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
 * [`8.1.15-slim`, `8.1-slim`, `latest-slim`, `nightly-slim`  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
-* [`7.9.18`, `7.9`, `7.9.18-edge`, `7.9-edge` (7.9/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/7.9/Dockerfile)
+* [`7.9.19`, `7.9`, `7.9.19-edge`, `7.9-edge` (7.9/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/7.9/Dockerfile)
 
 ## Quick Reference
 


### PR DESCRIPTION
Several backported updates and enhancements alongside updating to 7.9.19 version:
* Logging configuration updated with wrapper.log now being a symlink to stdout.  This eliminates the buffering lag from the previous wrapper console output.  Also synced entry point and script log output to match default wrapper log style.
* Now using tini as init replacement.
* Entrypoint now runs as root and uses gosu for step-down to IGNITION_UID/IGNITION_GID (default remains as 999:999).
* Now uses Ubuntu 20.04 base via eclipse-temurin openjdk base image (migrated from deprecated adoptopenjdk base used previously).
* Broke out module registration from entrypoint into separate script.
* Broke out jdbc registration from entrypoint into separate script and updated with latest class detection/replacement from 8.1.x image.