### PR TITLE
Simplify and harden UID/GID ownership updates

### DIFF
--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -722,7 +722,7 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
     # Stage tini as init replacement
     set -- tini -g -- "${CMD[@]}"
 
-    # Check for running as root and adjust permissions as needed, then stage dropdown to `ignition` user for gateway launch.
+    # Check for running as root and adjust ownership as needed, then stage dropdown to `ignition` user for gateway launch.
     if [ "$(id -u)" = "0" ] && [ "${IGNITION_UID}" != "0" ]; then
         # Obtain ignition UID/GID
         ignition_uid_current=$(id -u ignition)
@@ -737,33 +737,20 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
             groupmod -g "${IGNITION_GID}" ignition
         fi
 
-        # Ensure permissions of stdout for logging
+        # Ensure ownership of stdout for logging
         chown ignition:ignition logs/wrapper.log
 
-        # Adjust permissions of base Ignition paths
-        base_ignition_paths=(
+        # Adjust ownership of Ignition install files
+        ignition_paths=(
+            "${IGNITION_INSTALL_LOCATION}"
             "/var/lib/ignition"
             "/var/log/ignition"
         )
-        readarray -d '' pa_base_ignition_paths < <(find "${base_ignition_paths[@]}" -maxdepth 0 \! \( -user ignition -group ignition \) -print0)
-        if (( ${#pa_base_ignition_paths[@]} > 0 )); then
-            echo "init     | Adjusting permissions of base Ignition paths: ${pa_base_ignition_paths[*]}"
-            chown ignition:ignition "${base_ignition_paths[@]}"
-        fi
-
-        # Adjust permissions of Ignition install files
-        readarray -d '' pa_ignition_files < <(find -L "${IGNITION_INSTALL_LOCATION}" \! \( -user ignition -group ignition \) -a \! -name "wrapper.log" -print0)
+        readarray -d '' pa_ignition_files < <(find "${ignition_paths[@]}" \! \( -user ignition -group ignition \) -print0)
         if (( ${#pa_ignition_files[@]} > 0 )); then
-            echo "init     | Adjusting permissions of ${#pa_ignition_files[@]} Ignition installation files under '${IGNITION_INSTALL_LOCATION}', following symlinks..."
+            echo -n "init     | Adjusting ownership of ${#pa_ignition_files[@]} Ignition installation files..."
             # ignore failures with '|| true' here due to potentially broken symlink to metro-keystore (fresh launch)
-            chown -f ignition:ignition "${pa_ignition_files[@]}" || true
-        fi
-
-        # Adjust permissions of symlinks within Ignition install files
-        readarray -d '' pa_ignition_symlinks < <(find "${IGNITION_INSTALL_LOCATION}" "${base_ignition_paths[@]}" -type l \! \( -user ignition -group ignition \) -print0)
-        if (( ${#pa_ignition_symlinks[@]} > 0 )); then
-            echo "init     | Fine-tuning permissions of ${#pa_ignition_symlinks[@]} symlinks under: ${IGNITION_INSTALL_LOCATION} ${base_ignition_paths[*]}"
-            chown -h ignition:ignition "${pa_ignition_symlinks[@]}"
+            chown -h -f ignition:ignition "${pa_ignition_files[@]}" || true
         fi
 
         echo "init     | Staging user step-down from 'root' to 'ignition'"


### PR DESCRIPTION
### Background

Previous logic for UID/GID remapping included some ownership updates that could potentially affect paths outside of the Ignition installation folder[s].

### Overview

This PR simplifies the UID/GID ownership remapping (that occurs when `IGNITION_UID` and `IGNITION_GID` environment variables are supplied) and also ensures that no symlink traversal occurs.  This is the normal behavior used when you do a recursive `chown -R`.  The logic in the entrypoint script uses a `find` invocation to retrieve a count of files to be updated.  When updating in this manner, symlinks dereferencing must be explicitly disabled with the chown `-h` flag. 

### Testing

Verified the following behaviors:
- Adding a symlink to the Ignition installation folder (as the `ignition` user) pointing to another system path doesn't result in that target being reassigned ownership when the entrypoint runs (on a container restart, for example).
- File ownership within the Ignition installation folder are re-mapped when UID/GID env vars are supplied.
- Attempting to use a UID/GID that already exists in the base image still generates an error and the container exits.
- When omitting `IGNITION_UID` and `IGNITION_GID` vars, gateway still starts as `ignition` user (uid/gid 999), no extra files generated within the entrypoint are flagged for ownership changes.