### PR TITLE
Adding automatic release notes via GH actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,3 +15,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: Docker Image Build for kcollins/ignition:${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
This PR enables the `generate_release_notes` flag on the GH action we're using to generate the release upon a pushed tag.

Ref: https://github.com/softprops/action-gh-release