### PR TITLE
Fixed search for Subject Name in self-signed certs

### DIFF
--- a/7.9/register-modules.sh
+++ b/7.9/register-modules.sh
@@ -58,7 +58,7 @@ function register_modules() {
         cert_info=$( unzip -qq -c "${module_sourcepath}" certificates.p7b | $keytool -printcert -v | head -n 9 ) 
         thumbprint=$( echo "${cert_info}" | grep -A 2 "Certificate fingerprints" | grep SHA1 | cut -d : -f 2- | sed -e 's/\://g' | awk '{$1=$1;print tolower($0)}' ) 
         echo "init     |  Thumbprint: ${thumbprint}"
-        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
+        subject_name=$( echo "${cert_info}" | grep -m 1 -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
         echo "init     |  Subject Name: ${subject_name}"
         next_certificates_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(CERTIFICATES_ID)+1,1) FROM CERTIFICATES" ) 
         thumbprint_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM CERTIFICATES WHERE lower(hex(THUMBPRINT)) = '${thumbprint}'" )

--- a/8.1/register-modules.sh
+++ b/8.1/register-modules.sh
@@ -55,7 +55,7 @@ function register_modules() {
         cert_info=$( unzip -qq -c "${module_sourcepath}" certificates.p7b | $keytool -printcert -v | head -n 9 ) 
         thumbprint=$( echo "${cert_info}" | grep -A 2 "Certificate fingerprints" | grep SHA1 | cut -d : -f 2- | sed -e 's/\://g' | awk '{$1=$1;print tolower($0)}' ) 
         echo "init     |  Thumbprint: ${thumbprint}"
-        subject_name=$( echo "${cert_info}" | grep -A 1 "Certificate\[1\]:" | grep -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
+        subject_name=$( echo "${cert_info}" | grep -m 1 -Po '^Owner: CN="?\K(.+?)(?="?, (OU?|L|ST|C))' | sed -e 's/"//g' )
         echo "init     |  Subject Name: ${subject_name}"
         next_certificates_id=$( "${SQLITE3[@]}" "SELECT COALESCE(MAX(CERTIFICATES_ID)+1,1) FROM CERTIFICATES" ) 
         thumbprint_already_exists=$( "${SQLITE3[@]}" "SELECT 1 FROM CERTIFICATES WHERE lower(hex(THUMBPRINT)) = '${thumbprint}'" )


### PR DESCRIPTION
### 📖 Background

The automatic module registration currently looks for the first of multiple certificates to extract the _Subject Name_.  This breaks if the module is self-signed (and only has a single certificate in the chain).

### ⚙️ Overview

This PR modifies the filtering to eliminate the search for the first certificate, and instead simply limit the search for the _Subject Name_ to the first match of `Owner:`.

Fixes #110