### PR TITLE
Set Ubuntu Base images to 23.04

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,7 +1,7 @@
 # Default Build Edition - STABLE or NIGHTLY
 ARG BUILD_EDITION="STABLE"
 
-FROM ubuntu:22.04 AS downloader
+FROM ubuntu-base AS downloader
 LABEL maintainer="Kevin Collins <kcollins@purelinux.net>"
 ARG BUILD_EDITION
 
@@ -132,7 +132,7 @@ RUN xmlstarlet ed --inplace \
     data/logback.xml
 
 # RUNTIME IMAGE
-FROM ubuntu:22.04 as final
+FROM ubuntu-base as final
 LABEL maintainer="Kevin Collins <kcollins@purelinux.net>"
 ARG BUILD_EDITION
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,6 +33,9 @@ target "7_9-base" {
 
 target "8_1-base" {
     context = "8.1"
+    contexts = {
+        ubuntu-base = "docker-image://ubuntu:23.04"
+    }
     platforms = [
         "linux/amd64", 
         "linux/arm64", 


### PR DESCRIPTION
### ⚙️ Summary

This PR moves this image to the latest Ubuntu base images for 8.1.x, up to 23.04 from 22.04 LTS.