### PR TITLE
Add SBOM and Provenance attestations

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -45,3 +45,6 @@ jobs:
           files: ./docker-bake.hcl
           targets: ${{ inputs.build_target }}
           push: ${{ github.event_name != 'pull_request' }}
+          set: |
+            *.attest=type=provenance,mode=min
+            *.attest=type=sbom


### PR DESCRIPTION
### ⚙️ Summary

This PR adds SBOM and Provenance attestations to the build.  See the docs [here](https://docs.docker.com/build/attestations/) for more reference.

They're added only to the GH actions config.  If you want to apply them locally for testing, build with something similar to:

```bash
docker buildx bake 8_1-full --set 8_1-full.platform=linux/arm64 --push --set=8_1-base.attest=type=sbom --set=8_1-base.attest=type=provenance
```

I decided to leave them out of the bake definition since they can interfere with direct-loading of images for testing; you get this error trying to use `--load` with buildx bake and these new attestation settings:  `ERROR: docker exporter does not currently support exporting manifest lists`.