### PR TITLE
Added batching of chown operations

### DIFF
--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -748,9 +748,16 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
         )
         readarray -d '' pa_ignition_files < <(find "${ignition_paths[@]}" \! \( -user "${IGNITION_UID}" -group "${IGNITION_GID}" \) -print0)
         if (( ${#pa_ignition_files[@]} > 0 )); then
-            echo "init     | Adjusting ownership of ${#pa_ignition_files[@]} Ignition installation files..."
-            # ignore failures with '|| true' here due to potentially broken symlink to metro-keystore (fresh launch)
-            chown -h -f "${IGNITION_UID}:${IGNITION_GID}" "${pa_ignition_files[@]}" || true
+            batch_size=500
+            echo "init     | Adjusting ownership of ${#pa_ignition_files[@]} Ignition installation files (batch size ${batch_size})..."
+            looper=0
+            pa_ignition_files_batch=( "${pa_ignition_files[@]:$looper:$batch_size}" )
+            while (( ${#pa_ignition_files_batch[@]} > 0 )); do
+                # ignore failures with '|| true' here due to potentially broken symlink to metro-keystore (fresh launch)
+                chown -h -f "${IGNITION_UID}:${IGNITION_GID}" "${pa_ignition_files_batch[@]}" || true
+                looper=$((looper+batch_size))
+                pa_ignition_files_batch=( "${pa_ignition_files[@]:$looper:$batch_size}" )
+            done
         fi
 
         echo "init     | Staging user step-down from 'root'"


### PR DESCRIPTION
### 📖 Background

In some situations, with large numbers of existing files in an Ignition data volume, the existing per-file `chown` mechanism could fail due to a violation of bash MAX_ARGS count.

### ⚙️ Summary

This PR adds a simple batching of the chown calls with a size of 500 per invocation.  Changes applied to both 7.9 and 8.1 docker entry point scripts.