### PR TITLE
Updated 7.9 image base to Ubuntu 22.04

### DIFF
--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -100,7 +100,7 @@ RUN set -exo pipefail; \
     fi
 
 # RUNTIME IMAGE
-FROM eclipse-temurin:8-jre-focal as final
+FROM eclipse-temurin:8-jre-jammy as final
 LABEL maintainer "Kevin Collins <kcollins@purelinux.net>"
 
 # Install some prerequisite packages


### PR DESCRIPTION
### ⚙️ Summary

This PR freshens up the existing 7.9.21 definition with the latest Ubuntu 22.04 base image.