### PR TITLE
Add support for new modules

### DIFF
--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -134,7 +134,7 @@ enable_disable_modules() {
             # Reset MODULES_ENABLED based on supported modules for Maker Edition, necessary
             # when restoring from backup, where the native edition selection commissioning doesn't
             # handle purging the modules from the base install automatically.
-            MODULES_ENABLED="alarm-notification,allen-bradley-drivers,logix-driver,modbus-driver-v2,omron-driver,opc-ua,perspective,reporting,serial-support-gateway,sfc,siemens-drivers,sql-bridge,tag-historian,udp-tcp-drivers,user-manual,web-developer"
+            MODULES_ENABLED="alarm-notification,allen-bradley-drivers,logix-driver,mitsubishi-driver,modbus-driver-v2,omron-driver,opc-ua,perspective,reporting,serial-support-gateway,sfc,siemens-drivers,sql-bridge,tag-historian,udp-tcp-drivers,user-manual,web-developer"
         else
             return 0
         fi
@@ -149,7 +149,9 @@ enable_disable_modules() {
         ["BACnet Driver-module.modl"]="bacnet-driver"
         ["DNP3-Driver.modl"]="dnp3-driver"
         ["Enterprise Administration-module.modl"]="enterprise-administration"
+        ["IEC 61850 Driver-module.modl"]="iec-61850-driver"
         ["Logix Driver-module.modl"]="logix-driver"
+        ["Mitsubishi-Driver.modl"]="mitsubishi-driver"
         ["Mobile-module.modl"]="mobile-module"
         ["Modbus Driver v2-module.modl"]="modbus-driver-v2"
         ["Omron-Driver.modl"]="omron-driver"


### PR DESCRIPTION
### ⚙️ Summary

This PR adds support for recently introduced IEC-61850 and Mitsubishi Driver modules.  The IEC driver will also be filtered out when `GATEWAY_MODULES` is `all` (or undefined) and `IGNITION_EDITION` is `maker`, since it isn't a valid module for Maker Edition.  When specifying `GATEWAY_MODULES`, these drivers will no longer be skipped and thus included.