### PR TITLE
Eliminate pre-extraction of JRE for `-slim` images

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -100,11 +100,12 @@ RUN mkdir -p /var/lib/ignition && \
     ln -s /var/lib/ignition/data/local/metro-keystore webserver/metro-keystore
 
 # Extract embedded Java based on architecture
+ARG SKIP_JRE_EXTRACT="false"
 RUN set -exo pipefail; \
     dpkg_arch="$(dpkg --print-architecture | awk '{print toupper($0)}')"; \
     jre_suffix_env="IGNITION_${dpkg_arch}_JRE_SUFFIX"; \
     if [ -n "${!jre_suffix_env}" ]; then \
-        ./ignition.sh checkRuntimes && \
+        ([ "${SKIP_JRE_EXTRACT}" == "true" ] || ./ignition.sh checkRuntimes ) && \
         ln -s jre-${!jre_suffix_env} lib/runtime/jre; \
     else \
         echo "Architecture ${dpkg_arch} JRE suffix target not defined, aborting build"; \

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -572,6 +572,12 @@ if [[ "$1" != 'bash' && "$1" != 'sh' && "$1" != '/bin/sh' ]]; then
         "${APP_OPTIONS[@]}"
     )
 
+    # Extract the JRE if `java` command not present on path
+    if ! command -v java > /dev/null; then
+        echo "init     | Checking Ignition Runtimes..."
+        ./ignition.sh checkRuntimes
+    fi
+
     # Check for Upgrade and Mark Initialization File
     check_for_upgrade "${DATA_VOLUME_LOCATION}/.docker-init-complete"
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -103,6 +103,7 @@ target "8_1-slim" {
     args = {
         ZIP_EXCLUSION_RESOURCE_LIST = "designerlauncher,perspectiveworkstation,visionclientlauncher"
         ZIP_EXCLUSION_ARCHITECTURE_LIST = "mac,linux64,win64"
+        SKIP_JRE_EXTRACT = "true"
     }
     cache-to = ["type=registry,ref=${BASE_IMAGE_NAME}:cache-${IGNITION_VERSION_81}-slim"]
     cache-from = ["type=registry,ref=${BASE_IMAGE_NAME}:cache-${IGNITION_VERSION_81}-slim"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -113,25 +113,3 @@ target "8_1-slim" {
         "${BASE_IMAGE_NAME}:latest-slim"
     ]
 }
-
-target "nightly" {
-    inherits = ["8_1-full"]
-    args = {
-        BUILD_EDITION = "nightly"
-    }
-    no-cache = true
-    tags = [
-        "${BASE_IMAGE_NAME}:nightly"
-    ]
-}
-
-target "nightly-slim" {
-    inherits = ["8_1-slim"]
-    args = {
-        BUILD_EDITION = "nightly"
-    }
-    no-cache = true
-    tags = [
-        "${BASE_IMAGE_NAME}:nightly"
-    ]
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ## Supported tags and respective `Dockerfile` links
 
-* [`8.1.43`, `8.1`, `latest`, ~~`nightly`~~  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
-* [`8.1.43-slim`, `8.1-slim`, `latest-slim`, `nightly-slim`  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
+* [`8.1.43`, `8.1`, `latest`  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
+* [`8.1.43-slim`, `8.1-slim`, `latest-slim`,  (8.1/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/8.1/Dockerfile)
 * [`7.9.21`, `7.9`, `7.9.21-edge`, `7.9-edge` (7.9/Dockerfile)](https://github.com/thirdgen88/ignition-docker/blob/main/7.9/Dockerfile)
 
 ## Quick Reference


### PR DESCRIPTION
### ⚙️ Changes

* JRE no longer pre-extracted for `-slim` images, reducing image size by ~150M.  Entrypoint will invoke the `checkRuntimes` function if `java` is not found on the `PATH`.
* Cleaned up stale `nightly` build targets.

Fixes #168